### PR TITLE
Use root_path for redirect

### DIFF
--- a/asgi_auth_github/github_auth.py
+++ b/asgi_auth_github/github_auth.py
@@ -310,7 +310,7 @@ class GitHubAuth:
     def make_redirect_cookie(self, scope):
         """cookie to tell browser where to redirect post authentication"""
         redirect_cookie = SimpleCookie()
-        redirect_cookie[self.redirect_cookie_name] = scope["path"]
+        redirect_cookie[self.redirect_cookie_name] = scope["root_path"] + scope["path"]
         redirect_cookie[self.redirect_cookie_name]["path"] = "/"
         return redirect_cookie
 


### PR DESCRIPTION
In Starlette, I'm using something like this:
```python
auth_app = GitHubAuth(...)
app.mount('/admin', app=auth_app)
```
In this case, `scope["path"] == "/"` and `scope["root_path"] == "/admin"`.
As a result the redirect cookie becomes `/`, but I'd like it to redirect to `/admin/` instead.

This PR fixes that by prefixing the redirect path with `scope["root_path"]`.