### PR TITLE
Require wheel in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
     extras_require={"test": ["pytest", "pytest-asyncio", "asgiref~=3.1.2"]},
     tests_require=["asgi-auth-github[test]"],
     package_data={"asgi_auth_github": ["templates/*.html"]},
+    setup_requires=['wheel']
 )


### PR DESCRIPTION
When adding the following in my requirements.txt:
`git+https://github.com/Jaapp-/asgi-auth-github@master#egg=asgi-auth-github`
and install from a new virtualenv, I get an error like this:
`error: invalid command 'bdist_wheel'`
https://stackoverflow.com/questions/34819221/why-is-python-setup-py-saying-invalid-command-bdist-wheel-on-travis-ci

As per the answers, adding the following fixes that.
```
setup(
    ...
    setup_requires=['wheel']
)
```